### PR TITLE
Use exact 6.0.203

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest, macOS-latest]
-        dotnet: [6.0.400]
+        dotnet: [6.0.203]
     runs-on: ${{ matrix.os }}
 
     steps:


### PR DESCRIPTION
Documentation generation still didn't work as expected.
Using the same SDK version now as `FSharp.Formatting` has.